### PR TITLE
little tweak to not throw an exception on RFC1918 IP address

### DIFF
--- a/geoparser.py
+++ b/geoparser.py
@@ -14,6 +14,7 @@ import geoip2.database
 import Geohash
 import configparser
 from influxdb import InfluxDBClient
+from IPy import IP as ipadd
 
 def logparse(LOGPATH, INFLUXHOST, INFLUXPORT, INFLUXDBDB, INFLUXUSER, INFLUXUSERPASS, MEASUREMENT, GEOIPDB, INODE): # NOQA
     # Preparing variables and params
@@ -52,7 +53,7 @@ def logparse(LOGPATH, INFLUXHOST, INFLUXPORT, INFLUXDBDB, INFLUXUSER, INFLUXUSER
                     m = re_IPV6.match(LINE)
                     IP = m.group(1)
 
-                if IP:
+                if ipadd(IP).iptype() == 'PUBLIC'  and IP:
                     INFO = GI.city(IP)
                     if INFO is not None:
                         HASH = Geohash.encode(INFO.location.latitude, INFO.location.longitude) # NOQA

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ configparser==3.5.0
 influxdb==5.2.0
 Geohash==1.0
 geoip2==2.9.0
+IPy==1.00


### PR DESCRIPTION
I was having some errors with my nginx logs, because I have both external and internal access, so was getting `geoip2.errors.AddressNotFoundError: The address 192.168.168.1 is not in the database.`

I suspect that this should probably be handled better by geoip2, but in the meantime, I made a little check to simply ignore non-public IP addresses, and thought it might be useful